### PR TITLE
drvs and react-drvs helper functions

### DIFF
--- a/src/org/martinklepsch/derivatives.cljc
+++ b/src/org/martinklepsch/derivatives.cljc
@@ -3,6 +3,7 @@
             [org.martinklepsch.derived :as derived]
             [clojure.set :as s]
             [rum.core :as rum]
+            [rum.util :as rutil]
             #?(:cljs [goog.object :as gobj])))
 
 (defn depend'
@@ -166,6 +167,23 @@
   "Like `get-ref` wrapped in `rum.core/react`"
   [state drv-k]
   (rum/react (get-ref state drv-k)))
+
+(defn drvs [& ks]
+  (let [ds (map d/drv ks)
+        will-mount (rutil/collect :will-mount ds)
+        will-unmount (rutil/collect :will-unmount ds)]
+    {:class-properties (:class-properties (first ds))
+     :will-mount (fn [s]
+                   (assoc
+                     (rutil/call-all s will-mount)
+                     ::drvs ks))
+     :will-unmount (fn [s] (rutil/call-all s will-unmount))}))
+
+(defn react-drvs [state]
+  (map
+    (partial d/react state)
+    (::drvs state)))
+
 
 (comment 
   (def base (atom 0))

--- a/src/org/martinklepsch/derivatives.cljc
+++ b/src/org/martinklepsch/derivatives.cljc
@@ -169,7 +169,7 @@
   (rum/react (get-ref state drv-k)))
 
 (defn drvs [& ks]
-  (let [ds (map d/drv ks)
+  (let [ds (map drv ks)
         will-mount (rutil/collect :will-mount ds)
         will-unmount (rutil/collect :will-unmount ds)]
     {:class-properties (:class-properties (first ds))
@@ -181,7 +181,7 @@
 
 (defn react-drvs [state]
   (map
-    (partial d/react state)
+    (partial react state)
     (::drvs state)))
 
 


### PR DESCRIPTION
This lets you do this:

```clojure
(rum/defcs block < rum/reactive (d/drvs :product/page :product/images :product/text) 
  [state]
  (let [[page images text] (d/react-drvs state)] 
     ...)
```

which is a lot nicer than having to do this:

```clojure
(rum/defcs block < rum/reactive (d/drv :product/page) (d/drv :product/images) (d/drv :product/text) 
  [state]
  (let [page (d/react state :product/page)
        images (d/react state :product/images)
        text (d/react state :product/text)] 
     ...)
```