### PR TITLE
Improved drv mixin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,13 +13,20 @@
      ...))
 ```
 
-Now it is possible to combine these calls with `org.martinklepsch.derivatives/drvs`:
+Now it is possible to pass multiple keywords to `org.martinklepsch.derivatives/drv` and also there is a new function
+`react-drvs` that can be used to dereference multiple derivatives at once:
 
 ```clojure
-(rum/defcs block < rum/reactive (d/drvs :product/page :product/images :product/text) 
+(rum/defcs block < rum/reactive (d/drv :product/page :product/images :product/text)
   [state]
-  (let [[page images text] (d/react-drvs state)] 
+  (let [{:keys [:product/text]} (d/react-drvs state)]
+    [:p text]
       ...))
+```
+
+```clojure
+(d/react-drvs state) -> {:product/page 'val :product/images 'val :product/text 'val}
+(d/react-drvs state :product/page) -> {:product/page 'val}
 ```
 
 ### 0.1.1

--- a/boot.properties
+++ b/boot.properties
@@ -1,6 +1,6 @@
 #http://boot-clj.com
 #Wed Jun 29 15:32:45 CEST 2016
 BOOT_CLOJURE_NAME=org.clojure/clojure
-BOOT_CLOJURE_VERSION=1.9.0-alpha8
+BOOT_CLOJURE_VERSION=1.9.0-alpha14
 BOOT_VERSION=2.6.0
 BOOT_EMIT_TARGET=no

--- a/build.boot
+++ b/build.boot
@@ -1,11 +1,12 @@
 (set-env!
  :resource-paths  #{"src"}
  :dependencies '[[adzerk/bootlaces          "0.1.13"     :scope "test"]
-                 [adzerk/boot-cljs          "1.7.228-1"  :scope "test"]
+                 [adzerk/boot-cljs          "1.7.228-2"  :scope "test"]
                  [adzerk/boot-test          "1.1.2"      :scope "test"]
-                 [adzerk/boot-reload        "0.4.11"     :scope "test"]
+                 [adzerk/boot-reload        "0.4.13"     :scope "test"]
                  [pandeiro/boot-http        "0.7.3"      :scope "test"]
-                 [org.clojure/clojurescript "1.9.93"     :scope "provided"]
+                 [org.clojure/clojure       "1.9.0-alpha14" :scope "provided"]
+                 [org.clojure/clojurescript "1.9.293"     :scope "provided"]
                  [com.stuartsierra/dependency "0.2.0"]
                  [rum "0.10.5"]])
 

--- a/src/org/martinklepsch/derivatives.cljc
+++ b/src/org/martinklepsch/derivatives.cljc
@@ -168,7 +168,7 @@
   [state drv-k]
   (rum/react (get-ref state drv-k)))
 
-(defn react-drvs
+(defn react-all
   "React to multiple derivatives in the components state.
    If any `ks` are passed, react to those and return their values
    in a map. If no `ks` is passed return all available derivatives

--- a/src/org/martinklepsch/derivatives.cljc
+++ b/src/org/martinklepsch/derivatives.cljc
@@ -149,21 +149,7 @@
           :will-unmount  (fn [s]
                            (let [release-drv! (-> s :rum/react-component (gobj/get "context") (gobj/get release-k))]
                              (assert release-drv! "No release! derivative function found in component context")
-                             (reduce #(do (release-drv! %2 token) (update %1 ::derivatives dissoc %2)) s drv-ks)))})))
-
-  #_(defn drvs
-    "Rum mixin similar to `drv` except that you can supply multiple derivative identifiers"
-    [& drv-ks]
-    #?(:cljs
-       (let [ds           (map drv drv-ks)
-             will-mount   (rutil/collect :will-mount ds)
-             will-unmount (rutil/collect :will-unmount ds)]
-         {:class-properties {:contextTypes context-types}
-          :will-mount (fn [s]
-                        (assoc
-                         (rutil/call-all s will-mount)
-                         ::drvs drv-ks))
-          :will-unmount (fn [s] (rutil/call-all s will-unmount))}))))
+                             (reduce #(do (release-drv! %2 token) (update %1 ::derivatives dissoc %2)) s drv-ks)))}))))
 
 (def ^:dynamic *derivatives* nil)
 

--- a/src/org/martinklepsch/derivatives.cljc
+++ b/src/org/martinklepsch/derivatives.cljc
@@ -175,7 +175,7 @@
          :clj  (get *derivatives* drv-k))
       (throw (ex-info (str "No derivative found! Maybe you forgot a (drv " drv-k ") mixin?")
                       {:key drv-k :derivatives #?(:cljs (keys (::derivatives state))
-                                                  :clj (keys *derivatives*))}))))
+                                                  :clj  (keys *derivatives*))}))))
 
 (defn react
   "Like `get-ref` wrapped in `rum.core/react`"
@@ -183,8 +183,8 @@
   (rum/react (get-ref state drv-k)))
 
 (defn react-drvs [state & ks]
-  (->> (if (seq ks) ks (-> state ::derivatives keys))
-       (map #(react state %))))
+  (let [ks (or (seq ks) (-> state ::derivatives keys))]
+    (zipmap ks (map #(react state %) ks))))
 
 (comment 
   (def base (atom 0))

--- a/src/org/martinklepsch/derivatives.cljc
+++ b/src/org/martinklepsch/derivatives.cljc
@@ -168,7 +168,12 @@
   [state drv-k]
   (rum/react (get-ref state drv-k)))
 
-(defn react-drvs [state & ks]
+(defn react-drvs
+  "React to multiple derivatives in the components state.
+   If any `ks` are passed, react to those and return their values
+   in a map. If no `ks` is passed return all available derivatives
+   deref'ed as a map."
+  [state & ks]
   (let [ks (or (seq ks) (-> state ::derivatives keys))]
     (zipmap ks (map #(react state %) ks))))
 


### PR DESCRIPTION
- Instead of introducing another mixin the `drv` mixin is now variadic, allowing multiple derivative IDs to be passed. 
- Also the `react-drvs` function now returns a map instead of a vector making it more predictable for destructuring. 

I'd like to come up with another name for `react-drvs` as well. Essentially `react` also reacts to derivatives so it feels like it doesn't point out the "multiple" part very well. Some ideas:
- `react-multiple`
- `react-multi`
- `react-many`

All not very inspired, I know, any better ideas certainly welcome! :)

Technically we could also combine these (return the value if only one keyword is passed), but that's probably a bad idea.

/via #7 