### PR TITLE
Add API docs script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Derivatives [![CircleCI](https://circleci.com/gh/martinklepsch/derivatives.svg?style=svg)](https://circleci.com/gh/martinklepsch/derivatives)
 
-[usage](#usage) | [comparisons](#comparisons) | [change log](https://github.com/martinklepsch/derivatives/blob/master/CHANGES.md)
+[usage](#usage) | [comparisons](#comparisons) | [change log](https://github.com/martinklepsch/derivatives/blob/master/CHANGES.md) | [API docs](https://martinklepsch.github.io/derivatives/)
 
 **A note on terminology:** There are a lot of things with similar meanings/use-cases around: subscriptions, reactions, derived atoms, view models. 
 I'll introduce another to make things even worse: *derivative*. A *derivative* implements `IWatchable` and it's value is the result of applying a function to the value of other things (*sources*) implementing `IWatchable`. Whenever any of the *sources* change the value of the *derivative* is updated.

--- a/build.boot
+++ b/build.boot
@@ -5,6 +5,7 @@
                  [adzerk/boot-test          "1.1.2"      :scope "test"]
                  [adzerk/boot-reload        "0.4.13"     :scope "test"]
                  [pandeiro/boot-http        "0.7.3"      :scope "test"]
+                 [boot-codox                "0.10.3"     :scope "test"]
                  [org.clojure/clojure       "1.9.0-alpha14" :scope "provided"]
                  [org.clojure/clojurescript "1.9.293"     :scope "provided"]
                  [com.stuartsierra/dependency "0.2.0"]
@@ -26,7 +27,8 @@
  '[adzerk.boot-cljs      :refer [cljs]]
  '[adzerk.boot-test      :refer [test]]
  '[adzerk.boot-reload    :refer [reload]]
- '[pandeiro.boot-http    :refer [serve]])
+ '[pandeiro.boot-http    :refer [serve]]
+ '[codox.boot :refer [codox]])
 
 (bootlaces! +version+)
 

--- a/generate_docs
+++ b/generate_docs
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Keep a separate branch of generated API docs.
+#
+# This script generates API documentation, commits it to a separate branch, and
+# pushes it upstream. It does this without actually checking out the branch,
+# using a separate working tree directory, so without any disruption to your
+# current working tree. You can have local file modifications, but the git index
+# (staging area) must be clean.
+
+# The git remote to fetch and push to. Also used to find the parent commit.
+TARGET_REMOTE="origin"
+
+# Branch name to commit and push to
+TARGET_BRANCH="gh-pages"
+
+# Command that generates the API docs
+DOC_CMD="boot codox -n derivatives -o gh-pages -s src target"
+
+# Working tree directory. The output of $DOC_CMD must end up in this directory.
+WORK_TREE="target/gh-pages"
+
+if ! git diff-index --quiet --cached HEAD ; then
+    echo "Git index isn't clean. Make sure you have no staged changes. (try 'git reset .')"
+    exit
+fi
+
+git fetch $TARGET_REMOTE
+rm -rf $WORK_TREE
+mkdir -p $WORK_TREE
+
+echo "Generating docs"
+$DOC_CMD
+
+echo "Adding file to git index"
+git --work-tree=$WORK_TREE add -A
+
+TREE=`git write-tree`
+echo "Created git tree $TREE"
+
+if git show-ref --quiet --verify "refs/remotes/${TARGET_REMOTE}/${TARGET_BRANCH}" ; then
+    PARENT=`git rev-parse ${TARGET_REMOTE}/${TARGET_BRANCH}`
+    echo "Creating commit with parent ${PARENT} ${TARGET_REMOTE}/${TARGET_BRANCH}"
+    COMMIT=`git commit-tree -p $PARENT $TREE -m 'Updating docs'`
+else
+    echo "Creating first commit of the branch"
+    COMMIT=`git commit-tree $TREE -m 'Updating docs'`
+fi
+
+echo "Commit $COMMIT"
+echo "Pushing to $TARGET_BRANCH"
+
+git reset .
+git push $TARGET_REMOTE $COMMIT:refs/heads/$TARGET_BRANCH
+git fetch
+echo
+git log -1 --stat $TARGET_REMOTE/$TARGET_BRANCH


### PR DESCRIPTION
Add the generate_docs script to generate docs and push them to gh-pages.

Also adds codox to build.boot, and links to the new docs from the README.

After merging you'll have to run `./generate_docs`, after that the gh-pages site will be live.

The result will look like this: https://plexus.github.io/derivatives/

And with that we have an example repo of using the codox+generate_docs with boot :)