### PR TITLE
Use separate prop-types package for compatibility with react16+

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -9,7 +9,8 @@
                  [org.clojure/clojure       "1.9.0-alpha14" :scope "provided"]
                  [org.clojure/clojurescript "1.9.293"     :scope "provided"]
                  [com.stuartsierra/dependency "0.2.0"]
-                 [rum "0.10.5"]])
+                 [rum "0.10.8"]
+                 [cljsjs/prop-types "15.5.10-1"]])
 
 (def +version+ "0.2.0")
 

--- a/src/org/martinklepsch/derivatives.cljc
+++ b/src/org/martinklepsch/derivatives.cljc
@@ -4,7 +4,8 @@
             [clojure.set :as s]
             [rum.core :as rum]
             [rum.util :as rutil]
-            #?(:cljs [goog.object :as gobj])))
+            #?@(:cljs [[goog.object :as gobj]
+                       [cljsjs.prop-types]])))
 
 (defn prefix-id []
   #?(:cljs (random-uuid)
@@ -126,8 +127,8 @@
 
 (let [get-k     "org.martinklepsch.derivatives/get"
       release-k "org.martinklepsch.derivatives/release"
-      context-types #?(:cljs {get-k     js/React.PropTypes.func
-                              release-k js/React.PropTypes.func}
+      context-types #?(:cljs {get-k     js/PropTypes.func
+                              release-k js/PropTypes.func}
                        :clj  {})]
 
   (defn rum-derivatives


### PR DESCRIPTION
Using this library issues a warning regarding the fact that `PropTypes` will need to be accessed from a separate package starting with react16. 

The version of the cljsjs/prop-types library used is the one recommended in the [rum readme](https://github.com/tonsky/rum/tree/348da5f6cc1fde391217f7a4134f12f4043c87ed)


