### PR TITLE
Static properties

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -10,9 +10,9 @@
                  [org.clojure/clojurescript "1.9.946"     :scope "provided"]
                  [com.stuartsierra/dependency "0.2.0"]
                  [rum "0.10.8"]
-                 [cljsjs/prop-types "15.5.10-1"]])
+                 [cljsjs/prop-types "15.6.0-0"]])
 
-(def +version+ "0.3.0")
+(def +version+ "0.3.1")
 (def github "https://github.com/martinklepsch/derivatives")
 
 (task-options!

--- a/src/org/martinklepsch/derivatives.cljc
+++ b/src/org/martinklepsch/derivatives.cljc
@@ -137,7 +137,7 @@
     mixin."
     [spec]
     #?(:cljs
-       {:class-properties {:childContextTypes context-types}
+       {:static-properties {:childContextTypes context-types}
         :child-context    (fn [_] (let [pool (derivatives-pool spec)]
                                     {release-k (partial release! pool)
                                      get-k (partial get! pool)}))}))
@@ -146,7 +146,7 @@
     "Like rum-derivatives but get the spec from the arguments passed to the components (`:rum/args`) using `get-spec-fn`"
     [get-spec-fn]
     #?(:cljs
-       {:class-properties {:childContextTypes context-types}
+       {:static-properties {:childContextTypes context-types}
         :init             (fn [s _] (assoc s ::spec (get-spec-fn (:rum/args s))))
         :child-context    (fn [s] (let [pool (derivatives-pool (::spec s))]
                                     {release-k (partial release! pool)
@@ -159,7 +159,7 @@
     #?(:cljs
        (let [token (rand-int 10000)] ; TODO think of something better here
          (assert (seq drv-ks) "The drv mixin needs at least one derivative ID")
-         {:class-properties {:contextTypes context-types}
+         {:static-properties {:contextTypes context-types}
           :will-mount    (fn [s]
                            (let [get-drv! (-> s :rum/react-component (gobj/get "context") (gobj/get get-k))]
                              (assert get-drv! "No get! derivative function found in component context")


### PR DESCRIPTION
NB: I'm not sure that this is retro compatible with old versions of React, it needs testing.

Upgrading to React 16.2.0 (cljsjs 16.2.0-3) i had this warnings

<img width="1440" alt="screen shot 2018-02-20 at 4 37 19 pm" src="https://user-images.githubusercontent.com/642704/36441299-7a4e5c54-1672-11e8-9978-8137ef7e4e76.png">

So i went through all our dependencies to see where the problem was and i found out that the prop-types now needs to be set as `static-properties` instead of `:class-properties`.

You can see our related PR [here](https://github.com/open-company/open-company-web/pull/374).